### PR TITLE
Fix invalid formatting for health check error

### DIFF
--- a/tcheck.go
+++ b/tcheck.go
@@ -63,7 +63,7 @@ func main() {
 	val, err := client.Health(ctx)
 
 	if err != nil {
-		fmt.Printf("NOT OK %v\n", *serviceName, err)
+		fmt.Printf("NOT OK %v\nError: %v\n", *serviceName, err)
 		os.Exit(2)
 	} else if val.Ok != true {
 		fmt.Printf("NOT OK %v\n", *val.Message)


### PR DESCRIPTION
The Printf has a single formatting directive but passes 2 arguments.
This causes it to print an ugly message like:

```
  NOT OK testing\n%!(EXTRA tchannel.SystemError=tchannel error
  ErrCodeBadRequest: no handler for service \"testing\" and method \"Meta::health\")" (actual)N
```

Fix the formatting to print the error on a separate line, and add a test

@rf @blampe @akshayjshah 
