### PR TITLE
Fix panic if tcheck receives not ok without a message

### DIFF
--- a/tcheck.go
+++ b/tcheck.go
@@ -109,7 +109,7 @@ func healthCheck(peer, serviceName string, timeout time.Duration) error {
 		return exitError{_exitUnknownUnhealthy, fmt.Sprintf("NOT OK %v\nError: %v\n", serviceName, err)}
 	}
 	if val.Ok != true {
-		return exitError{_exitExplicitUnhealthy, fmt.Sprintf("NOT OK %v\n", *val.Message)}
+		return exitError{_exitExplicitUnhealthy, fmt.Sprintf("NOT OK %v\n", val.GetMessage())}
 	}
 
 	return nil

--- a/tcheck_test.go
+++ b/tcheck_test.go
@@ -28,12 +28,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/testutils"
-	"github.com/uber/tchannel-go/thrift"
+	"github.com/uber/tcheck/internal/gen-go/meta"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/thrift"
 )
 
 func healthNotOk(ctx thrift.Context) (ok bool, message string) {
@@ -191,6 +192,29 @@ func TestIntegrationSuccess(t *testing.T) {
 
 	os.Args = []string{"tcheck", "--peer", server.PeerInfo().HostPort, "--serviceName", server.ServiceName()}
 	main()
+}
+
+type unhealthyHandler struct {
+	// Embed interface so unimplemented methods cause panic.
+	meta.TChanMeta
+}
+
+func (unhealthyHandler) Health(_ thrift.Context) (*meta.HealthStatus, error) {
+	return &meta.HealthStatus{
+		Ok: false,
+	}, nil
+}
+
+func TestIntegrationNotOKNoMessage(t *testing.T) {
+	server := setupServer(t, nil)
+	defer server.Close()
+
+	tServer := thrift.NewServer(server)
+	tServer.Register(meta.NewTChanMetaServer(unhealthyHandler{}))
+
+	err := healthCheck(server.PeerInfo().HostPort, server.ServiceName(), time.Second)
+	require.Error(t, err, "Expected health check to fail")
+	assert.Equal(t, _exitExplicitUnhealthy, getExitCode(err), "Unexpected exit code")
 }
 
 func TestIntegrationError(t *testing.T) {


### PR DESCRIPTION
Previously, we dereferenced `Message` without doing a `nil` check when we received a `!ok` response. Since the message is optional, services that returned unhealthy without a message caused tcheck to panic.

Use `GetMessage()` instead which will return an empty string if the field is not set.